### PR TITLE
Removed duplicate functions using optional values

### DIFF
--- a/SuperRecord/NSFetchedResultsControllerExtension.swift
+++ b/SuperRecord/NSFetchedResultsControllerExtension.swift
@@ -99,7 +99,7 @@ extension NSFetchedResultsController {
         return superFetchedResultsController(entityName, sectionNameKeyPath: sectionNameKeyPath, sortDescriptors: sortDescriptors, predicate:nil, delegate: delegate)
     }
     
-    private class func superFetchedResultsController(entityName: NSString!, sectionNameKeyPath: NSString?, sortDescriptors: NSArray?, predicate: NSPredicate?, delegate: NSFetchedResultsControllerDelegate, context: NSManagedObjectContext!) -> NSFetchedResultsController {
+    private class func superFetchedResultsController(entityName: NSString!, sectionNameKeyPath: NSString?, sortDescriptors: NSArray?, predicate: NSPredicate?, delegate: NSFetchedResultsControllerDelegate, context: NSManagedObjectContext! = SuperCoreDataStack.defaultStack.managedObjectContext!) -> NSFetchedResultsController {
         
         let fetchRequest = NSFetchRequest(entityName: entityName)
         fetchRequest.entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context)
@@ -133,8 +133,4 @@ extension NSFetchedResultsController {
         return tempFetchedResultsController
     }
     
-    private class func superFetchedResultsController(entityName: NSString!, sectionNameKeyPath: NSString?, sortDescriptors: NSArray?, predicate: NSPredicate? , delegate: NSFetchedResultsControllerDelegate) -> NSFetchedResultsController {
-        let context = SuperCoreDataStack.defaultStack.managedObjectContext!
-        return superFetchedResultsController(entityName, sectionNameKeyPath: sectionNameKeyPath, sortDescriptors: sortDescriptors, predicate: predicate, delegate: delegate, context: context)
-    }
 }

--- a/SuperRecord/NSManagedObjectExtension.swift
+++ b/SuperRecord/NSManagedObjectExtension.swift
@@ -13,7 +13,7 @@ import CoreData
 
 extension NSManagedObject {
 
-    class func findAllWithPredicate(predicate: NSPredicate!, context: NSManagedObjectContext) -> NSArray {
+    class func findAllWithPredicate(predicate: NSPredicate!, context: NSManagedObjectContext = SuperCoreDataStack.defaultStack.managedObjectContext!) -> NSArray {
     
         var entityName : NSString = NSStringFromClass(self)        
         let entityDescription = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context)
@@ -28,21 +28,11 @@ extension NSManagedObject {
         return results
     }
     
-    class func findAllWithPredicate(predicate: NSPredicate!) -> NSArray {
-        let context = SuperCoreDataStack.defaultStack.managedObjectContext!
-        return findAllWithPredicate(predicate, context: context)
-    }
-
-    class func deleteAll(context: NSManagedObjectContext) -> Void {
+    class func deleteAll(context: NSManagedObjectContext = SuperCoreDataStack.defaultStack.managedObjectContext!) -> Void {
         let results = findAll(context)
         for result in results {
             context.deleteObject(result as NSManagedObject)
         }
-    }
-    
-    class func deleteAll() -> Void {
-        let context = SuperCoreDataStack.defaultStack.managedObjectContext!
-        return deleteAll(context)
     }
     
     class func findAll(context: NSManagedObjectContext) -> NSArray {
@@ -50,8 +40,7 @@ extension NSManagedObject {
     }
     
     class func findAll() -> NSArray {
-        let context = SuperCoreDataStack.defaultStack.managedObjectContext!
-        return findAllWithPredicate(nil, context: context)
+        return findAllWithPredicate(nil)
     }
     
     class func findAllWithAttribute(attribute: NSString!, value: NSString!, context: NSManagedObjectContext) -> NSArray {
@@ -59,12 +48,7 @@ extension NSManagedObject {
         return findAllWithPredicate(predicate, context: context)
     }
     
-    class func findFirstOrCreateWithPredicate(predicate: NSPredicate!) -> NSManagedObject {
-        let context = SuperCoreDataStack.defaultStack.managedObjectContext!
-        return findFirstOrCreateWithPredicate(predicate, context: context)
-    }
-    
-    class func findFirstOrCreateWithPredicate(predicate: NSPredicate!, context: NSManagedObjectContext) -> NSManagedObject {
+    class func findFirstOrCreateWithPredicate(predicate: NSPredicate!, context: NSManagedObjectContext = SuperCoreDataStack.defaultStack.managedObjectContext!) -> NSManagedObject {
         var entityName : NSString = NSStringFromClass(self)
         let entityDescription = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context)
         let fetchRequest = NSFetchRequest(entityName: entityName)
@@ -98,13 +82,9 @@ extension NSManagedObject {
         return createNewEntity(SuperCoreDataStack.defaultStack.managedObjectContext!)
     }
     
-    class func findFirstOrCreateWithAttribute(attribute: NSString!, value: NSString!, context: NSManagedObjectContext) -> NSManagedObject {
+    class func findFirstOrCreateWithAttribute(attribute: NSString!, value: NSString!, context: NSManagedObjectContext = SuperCoreDataStack.defaultStack.managedObjectContext!) -> NSManagedObject {
         let predicate = NSPredicate(format: "%K = %@", attribute,value)
         return findFirstOrCreateWithPredicate(predicate, context: context)
     }
     
-    class func findFirstOrCreateWithAttribute(attribute: NSString!, value: NSString!) -> NSManagedObject {
-        let context = SuperCoreDataStack.defaultStack.managedObjectContext!
-        return findFirstOrCreateWithAttribute(attribute, value: value, context: context)
-    }
 }


### PR DESCRIPTION
Hi!

I have removed all:

``` swift
let context = SuperCoreDataStack.defaultStack.managedObjectContext!
```

using swift optional values, so functions like

``` swift
class func findFirstOrCreateWithAttribute(attribute: NSString!, value: NSString!, context: NSManagedObjectContext) -> NSManagedObject 
```

Became

``` swift
class func findFirstOrCreateWithAttribute(attribute: NSString!, value: NSString!, context: NSManagedObjectContext = SuperCoreDataStack.defaultStack.managedObjectContext!) -> NSManagedObject 
```
