### PR TITLE
Add Logical & and | operator to NSPredicate

### DIFF
--- a/SuperRecord.xcodeproj/project.pbxproj
+++ b/SuperRecord.xcodeproj/project.pbxproj
@@ -7,12 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		12487FC71A25BFA20038C070 /* NSPredicateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12487FC61A25BFA20038C070 /* NSPredicateExtension.swift */; };
+		12487FCA1A25C41B0038C070 /* NSPredicateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12487FC61A25BFA20038C070 /* NSPredicateExtension.swift */; };
 		126BFA8A1A1F366600D59CE9 /* PokemonFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 126BFA891A1F366600D59CE9 /* PokemonFactory.swift */; };
 		126BFA8C1A1F506B00D59CE9 /* Pokemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 126BFA8B1A1F506B00D59CE9 /* Pokemon.swift */; };
 		129BB2361A1B58ED00D21867 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 129BB2311A1B58ED00D21867 /* Model.xcdatamodeld */; };
 		129BB2381A1B58ED00D21867 /* SuperRecordTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129BB2341A1B58ED00D21867 /* SuperRecordTestCase.swift */; };
 		129BB2391A1B58ED00D21867 /* Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129BB2351A1B58ED00D21867 /* Type.swift */; };
 		129BB23A1A1B593500D21867 /* SuperRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DDD65A19FA531800DAA557 /* SuperRecordTests.swift */; };
+		12D1B5691A30B9CA008F7859 /* NSPredicateExtensionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D1B5681A30B9CA008F7859 /* NSPredicateExtensionTest.swift */; };
 		12FEA4BC1A1E6A9B0034C5D4 /* NSManagedObjectExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FEA4BB1A1E6A9B0034C5D4 /* NSManagedObjectExtension.swift */; };
 		63DDD65419FA531800DAA557 /* SuperRecord.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63DDD64819FA531800DAA557 /* SuperRecord.framework */; };
 		63DDD6EA19FA598A00DAA557 /* NSFetchedResultsControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DDD6E819FA598A00DAA557 /* NSFetchedResultsControllerExtension.swift */; };
@@ -32,11 +35,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		12487FC61A25BFA20038C070 /* NSPredicateExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSPredicateExtension.swift; sourceTree = "<group>"; };
 		126BFA891A1F366600D59CE9 /* PokemonFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PokemonFactory.swift; sourceTree = "<group>"; };
 		126BFA8B1A1F506B00D59CE9 /* Pokemon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pokemon.swift; sourceTree = "<group>"; };
 		129BB2321A1B58ED00D21867 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		129BB2341A1B58ED00D21867 /* SuperRecordTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuperRecordTestCase.swift; sourceTree = "<group>"; };
 		129BB2351A1B58ED00D21867 /* Type.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Type.swift; sourceTree = "<group>"; };
+		12D1B5681A30B9CA008F7859 /* NSPredicateExtensionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensionTest.swift; sourceTree = "<group>"; };
 		12FEA4BB1A1E6A9B0034C5D4 /* NSManagedObjectExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSManagedObjectExtension.swift; sourceTree = "<group>"; };
 		63DDD64819FA531800DAA557 /* SuperRecord.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SuperRecord.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63DDD64C19FA531800DAA557 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -117,6 +122,7 @@
 				12FEA4BB1A1E6A9B0034C5D4 /* NSManagedObjectExtension.swift */,
 				63DDD65A19FA531800DAA557 /* SuperRecordTests.swift */,
 				63DDD65819FA531800DAA557 /* Supporting Files */,
+				12D1B5681A30B9CA008F7859 /* NSPredicateExtensionTest.swift */,
 			);
 			path = SuperRecordTests;
 			sourceTree = "<group>";
@@ -134,6 +140,7 @@
 			children = (
 				63DDD6E819FA598A00DAA557 /* NSFetchedResultsControllerExtension.swift */,
 				63DDD6E919FA598A00DAA557 /* NSManagedObjectExtension.swift */,
+				12487FC61A25BFA20038C070 /* NSPredicateExtension.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -257,6 +264,7 @@
 				63DDD6EF19FA599600DAA557 /* SuperFetchedResultsControllerDelegate.swift in Sources */,
 				63DDD6EE19FA599600DAA557 /* SuperCoreDataStack.swift in Sources */,
 				63DDD6EB19FA598A00DAA557 /* NSManagedObjectExtension.swift in Sources */,
+				12487FC71A25BFA20038C070 /* NSPredicateExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -268,9 +276,11 @@
 				126BFA8A1A1F366600D59CE9 /* PokemonFactory.swift in Sources */,
 				129BB2381A1B58ED00D21867 /* SuperRecordTestCase.swift in Sources */,
 				129BB2361A1B58ED00D21867 /* Model.xcdatamodeld in Sources */,
+				12487FCA1A25C41B0038C070 /* NSPredicateExtension.swift in Sources */,
 				12FEA4BC1A1E6A9B0034C5D4 /* NSManagedObjectExtension.swift in Sources */,
 				129BB23A1A1B593500D21867 /* SuperRecordTests.swift in Sources */,
 				129BB2391A1B58ED00D21867 /* Type.swift in Sources */,
+				12D1B5691A30B9CA008F7859 /* NSPredicateExtensionTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SuperRecord/NSPredicateExtension.swift
+++ b/SuperRecord/NSPredicateExtension.swift
@@ -1,0 +1,92 @@
+//
+//  NSPredicateExtension.swift
+//  SuperRecord
+//
+//  Created by Piergiuseppe Longo on 26/11/14.
+//  Copyright (c) 2014 Michael Armstrong. All rights reserved.
+//
+
+import Foundation
+
+//MARK: Logical operators
+/**
+Create a new NSPredicate as logical AND of left and right predicate
+
+:param: left
+:param: right
+
+:returns: NSPredicate
+*/
+func & (left : NSPredicate, right : NSPredicate )-> NSPredicate{
+    return [left] & [right]
+}
+
+/**
+Create a new NSPredicate as logical AND of left and right predicates
+
+:param: left
+:param: right a collection NSPredicate
+
+:returns: NSPredicate
+*/
+func & (left : NSPredicate, right : [NSPredicate] )-> NSPredicate{
+    return [left] & right
+}
+
+/**
+Create a new NSPredicate as logical AND of left and right predicates
+
+:param: left a collection NSPredicate
+:param: right a collection NSPredicate
+
+:returns: NSPredicate
+*/
+func & (left : [NSPredicate], right : [NSPredicate] )-> NSPredicate{
+    return NSCompoundPredicate.andPredicateWithSubpredicates(left + right)
+}
+
+/**
+
+Create a new NSPredicate as logical OR of left and right predicate
+
+:param: left
+:param: right
+
+:returns: NSPredicate
+*/
+
+func | (left : NSPredicate, right : NSPredicate )-> NSPredicate{
+    return [left] | [right]
+}
+
+/**
+
+Create a new NSPredicate as logical OR of left and right predicates
+
+:param: left
+:param: right a collection NSPredicate
+
+:returns: NSPredicate
+*/
+
+func | (left : NSPredicate, right : [NSPredicate] )-> NSPredicate{
+    return [left] | right
+}
+
+
+/**
+
+Create a new NSPredicate as logical OR of left and right predicates
+
+:param: left a collection NSPredicate
+:param: right a collection NSPredicate
+
+:returns: NSPredicate
+*/
+func | (left : [NSPredicate], right : [NSPredicate] )-> NSPredicate{
+    return NSCompoundPredicate.orPredicateWithSubpredicates(left + right)
+}
+
+extension NSPredicate {    
+
+}

--- a/SuperRecordTests/NSPredicateExtensionTest.swift
+++ b/SuperRecordTests/NSPredicateExtensionTest.swift
@@ -1,0 +1,79 @@
+//
+//  NSPredicateExtensionTest.swift
+//  SuperRecord
+//
+//  Created by Piergiuseppe Longo on 04/12/14.
+//  Copyright (c) 2014 Michael Armstrong. All rights reserved.
+//
+
+import UIKit
+import XCTest
+
+class NSPredicateExtensionTest: XCTestCase {
+
+    let firstLevelPredicate = NSPredicate(format: "level > 1")!
+    let secondLevelPredicate = NSPredicate (format: "level =< 36")!
+    
+    let typePredicate = NSPredicate(format: "type.id = 1")!
+    let namePredicate = NSPredicate (format: "name == Charmender")!
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    
+    func testAndPredicate(){
+        let expectedPredicate = NSPredicate (format: "level > 1 AND level =< 36");
+        let resultPredicate = firstLevelPredicate & secondLevelPredicate;
+        checkPreficate(expectedPredicate, resultPredicate: resultPredicate);
+    }
+    
+
+    func testOrPredicate(){
+        let expectedPredicate = NSPredicate (format: "level > 1 OR level =< 36");
+        let resultPredicate = firstLevelPredicate | secondLevelPredicate;
+        checkPreficate(expectedPredicate, resultPredicate: resultPredicate);
+    }
+    
+    func testAndPredicates(){
+        var expectedPredicate = NSPredicate (format: "level > 1 AND name == Charmender AND level =< 36");
+        var resultPredicate = [firstLevelPredicate, namePredicate] & [secondLevelPredicate];
+        checkPreficate(expectedPredicate, resultPredicate: resultPredicate);
+        
+        expectedPredicate = NSPredicate (format: "level > 1 AND name == Charmender AND level =< 36 AND type.id = 1");
+        resultPredicate = [firstLevelPredicate, namePredicate] & [secondLevelPredicate, typePredicate];
+        checkPreficate(expectedPredicate, resultPredicate: resultPredicate);
+        
+    }
+    
+    func testOrPredicates(){
+        var expectedPredicate = NSPredicate (format: "level > 1 OR name == Charmender OR level =< 36");
+        var resultPredicate = [firstLevelPredicate, namePredicate] | [secondLevelPredicate];
+        checkPreficate(expectedPredicate, resultPredicate: resultPredicate);
+        
+        expectedPredicate = NSPredicate (format: "level > 1 OR name == Charmender OR level =< 36 OR type.id = 1");
+        resultPredicate = [firstLevelPredicate, namePredicate] | [secondLevelPredicate, typePredicate];
+        checkPreficate(expectedPredicate, resultPredicate: resultPredicate);
+        
+    }
+    
+    func testMixedPredicates(){
+        var expectedPredicate = NSPredicate (format: "level > 1 AND name == Charmender OR level =< 36");
+        var resultPredicate = firstLevelPredicate & namePredicate | [secondLevelPredicate];
+        checkPreficate(expectedPredicate, resultPredicate: resultPredicate);
+    }
+    
+    private func checkPreficate(expectedPredicate : NSPredicate?, resultPredicate: NSPredicate?){
+        XCTAssertNotNil(expectedPredicate, "Shouldn't be nil")
+        XCTAssertNotNil(resultPredicate, "Shouldn't be nil")
+        XCTAssertEqual(expectedPredicate!, resultPredicate!, "Predicates mismatch")
+
+    }
+
+}


### PR DESCRIPTION
Here some example 

Defining:

``` swift
    let firstLevelPredicate = NSPredicate(format: "level > 1")!
    let secondLevelPredicate = NSPredicate (format: "level =< 36")!

    firstLevelPredicate & secondLevelPredicate // is equal to "level > 1 AND level =< 36"
    firstLevelPredicate | secondLevelPredicate  // is equal to "level > 1 OR level =< 36"
```

It is also possible to combine more than 1 NSPredicate and mixing operator

``` swift
    let firstLevelPredicate = NSPredicate(format: "level > 1")!
    let secondLevelPredicate = NSPredicate (format: "level =< 36")!
    let namePredicate = NSPredicate (format: "name == Charmender")!

    resultPredicate = firstLevelPredicate & namePredicate | [secondLevelPredicate] // is equal to "level > 1 AND name == Charmender OR level =< 36" 
```

It might be interesting adding more complex predicates as: "(level > 1 AND name == Charmender) OR (level =< 36)" and so on. 
