### PR TITLE
Add GroupBy

### DIFF
--- a/SuperRecord/NSManagedObjectExtension.swift
+++ b/SuperRecord/NSManagedObjectExtension.swift
@@ -276,7 +276,11 @@ public extension NSManagedObject {
         var results = max(context: context, fieldName: [fieldName], predicate: predicate, handler: handler)
         return results.isEmpty ? 0 : results[0];
     }
-    
+
+    class func max(context: NSManagedObjectContext = SuperCoreDataStack.defaultStack.managedObjectContext!, fieldName: [String], predicate : NSPredicate?, groupByField:[String], handler: ((NSError!) -> Void))-> [AnyObject] {
+        return function(context: context, function: "max:", fieldName: fieldName, predicate: predicate, groupByFieldName: groupByField, handler: handler)
+    }
+
     class func min(context: NSManagedObjectContext = SuperCoreDataStack.defaultStack.managedObjectContext!, fieldName: [String], predicate : NSPredicate?, handler: ((NSError!) -> Void)) -> [Double] {
         return function(context: context, function: "min:", fieldName: fieldName, predicate: predicate, handler: handler);
     }
@@ -286,6 +290,10 @@ public extension NSManagedObject {
         return results.isEmpty ? 0 : results[0];
     }
     
+    class func min(context: NSManagedObjectContext = SuperCoreDataStack.defaultStack.managedObjectContext!, fieldName: [String], predicate : NSPredicate?, groupByField:[String], handler: ((NSError!) -> Void))-> [AnyObject] {
+        return function(context: context, function: "min:", fieldName: fieldName, predicate: predicate, groupByFieldName: groupByField, handler: handler)
+    }
+
     class func avg(context: NSManagedObjectContext = SuperCoreDataStack.defaultStack.managedObjectContext!, fieldName: [String], predicate : NSPredicate?, handler: ((NSError!) -> Void)) -> [Double] {
         return function(context: context, function: "average:", fieldName: fieldName, predicate: predicate, handler: handler);
     }
@@ -294,4 +302,10 @@ public extension NSManagedObject {
         var results = avg(context: context, fieldName: [fieldName], predicate: predicate, handler: handler)
         return results.isEmpty ? 0 : results[0];
     }
+
+    class func avg(context: NSManagedObjectContext = SuperCoreDataStack.defaultStack.managedObjectContext!, fieldName: [String], predicate : NSPredicate?, groupByField:[String], handler: ((NSError!) -> Void))-> [AnyObject] {
+        return function(context: context, function: "average:", fieldName: fieldName, predicate: predicate, groupByFieldName: groupByField, handler: handler)
+    }
+
+
 }

--- a/SuperRecordTests/NSManagedObjectExtension.swift
+++ b/SuperRecordTests/NSManagedObjectExtension.swift
@@ -295,6 +295,36 @@ class NSManagedObjectExtension: SuperRecordTestCase {
      
     }
     
+    func testMaxGroupBy(){
+        let fireType = PokemonFactory.createType(managedObjectContext, id: .Fire, name: .Fire)
+        let waterType = PokemonFactory.createType(managedObjectContext, id: .Water, name: .Water)
+        
+        let Charmender = PokemonFactory.createPokemon(managedObjectContext, id: .Charmender, name: .Charmender, level: 1, type: fireType)
+        let Charmeleon = PokemonFactory.createPokemon(managedObjectContext, id: .Charmeleon, name: .Charmeleon, level: 16, type: fireType)
+        let Charizard = PokemonFactory.createPokemon(managedObjectContext, id: .Charizard, name: .Charizard, level: 36, type: fireType)
+        let Blastoise = PokemonFactory.createPokemon(managedObjectContext, id: .Blastoise, name: .Blastoise, level: 36, type: waterType)
+        managedObjectContext.save(&error)
+        
+        let expectedLevels : [String : Double] = ["Fire" : 36, "Water" : 36]
+        
+        let sumsExpectation = expectationWithDescription("max")
+        
+        var sumLevel = Pokemon.max(context: managedObjectContext, fieldName: ["level"], predicate: nil, groupByField: ["type.name", "type.id"],  handler:{error in
+            sumsExpectation.fulfill()
+        })
+        
+        waitForExpectationsWithTimeout(SuperRecordTestCaseTimeout, handler: { error in
+            for dictionay in sumLevel  {
+                let type : String! = dictionay["type.name"] as String!
+                let level : Double! = dictionay["level"] as Double!
+                let expectedLevel : Double = expectedLevels[type] as Double!
+                XCTAssertEqual(expectedLevel, level)
+            }
+        })
+        
+    }
+
+    
     func testMax(){
         let fireType = PokemonFactory.createType(managedObjectContext, id: .Fire, name: .Fire)
         let waterType = PokemonFactory.createType(managedObjectContext, id: .Water, name: .Water)
@@ -334,6 +364,35 @@ class NSManagedObjectExtension: SuperRecordTestCase {
 
     }
     
+    func testMinGroupBy(){
+        let fireType = PokemonFactory.createType(managedObjectContext, id: .Fire, name: .Fire)
+        let waterType = PokemonFactory.createType(managedObjectContext, id: .Water, name: .Water)
+        
+        let Charmender = PokemonFactory.createPokemon(managedObjectContext, id: .Charmender, name: .Charmender, level: 1, type: fireType)
+        let Charmeleon = PokemonFactory.createPokemon(managedObjectContext, id: .Charmeleon, name: .Charmeleon, level: 16, type: fireType)
+        let Charizard = PokemonFactory.createPokemon(managedObjectContext, id: .Charizard, name: .Charizard, level: 36, type: fireType)
+        let Blastoise = PokemonFactory.createPokemon(managedObjectContext, id: .Blastoise, name: .Blastoise, level: 36, type: waterType)
+        managedObjectContext.save(&error)
+        
+        let expectedLevels : [String : Double] = ["Fire" : 1, "Water" : 36]
+        
+        let sumsExpectation = expectationWithDescription("min")
+        
+        var sumLevel = Pokemon.min(context: managedObjectContext, fieldName: ["level"], predicate: nil, groupByField: ["type.name", "type.id"],  handler:{error in
+            sumsExpectation.fulfill()
+        })
+        
+        waitForExpectationsWithTimeout(SuperRecordTestCaseTimeout, handler: { error in
+            for dictionay in sumLevel  {
+                let type : String! = dictionay["type.name"] as String!
+                let level : Double! = dictionay["level"] as Double!
+                let expectedLevel : Double = expectedLevels[type] as Double!
+                XCTAssertEqual(expectedLevel, level)
+            }
+        })
+        
+    }
+    
     func testMin(){
         let fireType = PokemonFactory.createType(managedObjectContext, id: .Fire, name: .Fire)
         let waterType = PokemonFactory.createType(managedObjectContext, id: .Water, name: .Water)
@@ -369,6 +428,35 @@ class NSManagedObjectExtension: SuperRecordTestCase {
         
         waitForExpectationsWithTimeout(SuperRecordTestCaseTimeout, handler: { error in
             XCTAssertEqual(16, min, "Count mismatch")
+        })
+        
+    }
+    
+    func testAvgGroupBy(){
+        let fireType = PokemonFactory.createType(managedObjectContext, id: .Fire, name: .Fire)
+        let waterType = PokemonFactory.createType(managedObjectContext, id: .Water, name: .Water)
+        
+        let Charmender = PokemonFactory.createPokemon(managedObjectContext, id: .Charmender, name: .Charmender, level: 1, type: fireType)
+        let Charmeleon = PokemonFactory.createPokemon(managedObjectContext, id: .Charmeleon, name: .Charmeleon, level: 16, type: fireType)
+        let Charizard = PokemonFactory.createPokemon(managedObjectContext, id: .Charizard, name: .Charizard, level: 36, type: fireType)
+        let Blastoise = PokemonFactory.createPokemon(managedObjectContext, id: .Blastoise, name: .Blastoise, level: 36, type: waterType)
+        managedObjectContext.save(&error)
+        let fireAvg : Double = Double(36 + 1 + 16) / 3;
+        let expectedLevels : [String : Double] = ["Fire" : fireAvg , "Water" : 36]
+        
+        let sumsExpectation = expectationWithDescription("avg")
+        
+        var sumLevel = Pokemon.avg(context: managedObjectContext, fieldName: ["level"], predicate: nil, groupByField: ["type.name", "type.id"],  handler:{error in
+            sumsExpectation.fulfill()
+        })
+        
+        waitForExpectationsWithTimeout(SuperRecordTestCaseTimeout, handler: { error in
+            for dictionay in sumLevel  {
+                let type : String! = dictionay["type.name"] as String!
+                let level : Double! = dictionay["level"] as Double!
+                let expectedLevel : Double = expectedLevels[type] as Double!
+                XCTAssertEqual(expectedLevel, level)
+            }
         })
         
     }

--- a/SuperRecordTests/NSManagedObjectExtension.swift
+++ b/SuperRecordTests/NSManagedObjectExtension.swift
@@ -266,6 +266,35 @@ class NSManagedObjectExtension: SuperRecordTestCase {
 
     }
     
+    func testSumGroupBy(){
+        let fireType = PokemonFactory.createType(managedObjectContext, id: .Fire, name: .Fire)
+        let waterType = PokemonFactory.createType(managedObjectContext, id: .Water, name: .Water)
+        
+        let Charmender = PokemonFactory.createPokemon(managedObjectContext, id: .Charmender, name: .Charmender, level: 1, type: fireType)
+        let Charmeleon = PokemonFactory.createPokemon(managedObjectContext, id: .Charmeleon, name: .Charmeleon, level: 16, type: fireType)
+        let Charizard = PokemonFactory.createPokemon(managedObjectContext, id: .Charizard, name: .Charizard, level: 36, type: fireType)
+        let Blastoise = PokemonFactory.createPokemon(managedObjectContext, id: .Blastoise, name: .Blastoise, level: 36, type: waterType)
+        managedObjectContext.save(&error)
+
+        let expectedLevels : [String : Double] = ["Fire" : 53, "Water" : 36]
+    
+        let sumsExpectation = expectationWithDescription("Sum")
+    
+        var sumLevel = Pokemon.sum(context: managedObjectContext, fieldName: ["level"], predicate: nil, groupByField: ["type.name", "type.id"],  handler:{error in
+            sumsExpectation.fulfill()
+        })
+        
+        waitForExpectationsWithTimeout(SuperRecordTestCaseTimeout, handler: { error in
+            for dictionay in sumLevel  {
+                let type : String! = dictionay["type.name"] as String!
+                let level : Double! = dictionay["level"] as Double!
+                let expectedLevel : Double = expectedLevels[type] as Double!
+                XCTAssertEqual(expectedLevel, level)
+            }
+        })
+     
+    }
+    
     func testMax(){
         let fireType = PokemonFactory.createType(managedObjectContext, id: .Fire, name: .Fire)
         let waterType = PokemonFactory.createType(managedObjectContext, id: .Water, name: .Water)


### PR DESCRIPTION
I have add groupBy functionality to all function with tests:
1. Sum
2. Max
3. Min
4. Avg

Here an example
```swift
let fireType = PokemonFactory.createType(context, id: .Fire, name: .Fire)
let waterType = PokemonFactory.createType(context, id: .Water, name: .Water)
let Charmender = PokemonFactory.createPokemon(context, id: .Charmender, name: .Charmender, level: 1, type: fireType)
let Charmeleon = PokemonFactory.createPokemon(context, id: .Charmeleon, name: .Charmeleon, level: 16, type: fireType)
let Charizard = PokemonFactory.createPokemon(context, id: .Charizard, name: .Charizard, level: 36, type: fireType)
let Blastoise = PokemonFactory.createPokemon(context, id: .Blastoise, name: .Blastoise, level: 36, type: waterType)
Pokemon.sum(context: context, fieldName: ["level"], predicate: nil, groupByField: ["type.name", "type.id"],  handler: nil) 
```

As expected returns  ["Fire" : 53, "Water" : 36]
