### PR TITLE
Fixed random SQLite error code:522, 'not an error'

### DIFF
--- a/SuperRecordTests/NSManagedObjectExtension.swift
+++ b/SuperRecordTests/NSManagedObjectExtension.swift
@@ -259,8 +259,6 @@ class NSManagedObjectExtension: SuperRecordTestCase {
             try managedObjectContext.save()
         } catch _ {
         };
-
-        var error: NSError? = nil
     
         let levelPredicate = NSPredicate.predicateBuilder("level", value: 5, predicateOperator: NSPredicateOperator.GreaterThan);
         let typePredicate = NSPredicate.predicateBuilder("type", value: fireType, predicateOperator: NSPredicateOperator.Equal);

--- a/SuperRecordTests/SuperRecordTestCase.swift
+++ b/SuperRecordTests/SuperRecordTestCase.swift
@@ -19,7 +19,8 @@ class SuperRecordTestCase: XCTestCase {
     
     var managedObjectContext  = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.MainQueueConcurrencyType)
     var error: NSError? = nil
-    
+    var psc : NSPersistentStoreCoordinator!
+
     let applicationDocumentsDirectory: NSURL = {
         let urls = NSFileManager.defaultManager().URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask)
         return urls.last!
@@ -30,13 +31,9 @@ class SuperRecordTestCase: XCTestCase {
     override func setUp() {
         super.setUp();
         let url = self.applicationDocumentsDirectory.URLByAppendingPathComponent("Pokemon.sqlite")
-        do {
-            try NSFileManager.defaultManager().removeItemAtURL(url)
-        } catch _ {
-        }
         var error: NSError? = nil
         let mom : NSManagedObjectModel = NSManagedObjectModel.mergedModelFromBundles(NSBundle.allBundles())!;
-        let psc : NSPersistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: mom);
+        psc  = NSPersistentStoreCoordinator(managedObjectModel: mom);
         try! psc.addPersistentStoreWithType(
             NSSQLiteStoreType,
             configuration: nil,
@@ -64,6 +61,11 @@ class SuperRecordTestCase: XCTestCase {
         };
         if(error != nil){
             XCTFail("Cannot save context: \(error?.localizedDescription)");
+        }
+        let stores = psc.persistentStores
+        for store in stores{
+            try! psc.removePersistentStore(store)
+            try! NSFileManager.defaultManager().removeItemAtURL(store.URL!)
         }
         super.tearDown();
     }


### PR DESCRIPTION
I've fixed an error that can affect some Simulator (mine for example) running unit-test. 

> 2015-10-21 17:10:24.579 xctest[703:8687] CoreData: error: (522) I/O error for database at /Users/*/Library/Developer/CoreSimulator/Devices/5E7487DC-2883-45F6-8CC1-FB90A2EB73C1/data/Documents/Pokemon.sqlite.  SQLite error code:522, 'not an error'
fatal error: 'try!' expression unexpectedly raised an error: Error Domain=NSCocoaErrorDomain Code=522 "(null)" UserInfo={NSSQLiteErrorDomain=522, NSUnderlyingException=I/O error for database at /Users/*/Library/Developer/CoreSimulator/Devices/5E7487DC-2883-45F6-8CC1-FB90A2EB73C1/data/Documents/Pokemon.sqlite.  SQLite error code:522, 'not an error', NSFilePath=/Users/*/Library/Developer/CoreSimulator/Devices/5E7487DC-2883-45F6-8CC1-FB90A2EB73C1/data/Documents/Pokemon.sqlite}: file /Library/Caches/com.apple.xbs/Sources/swiftlang/swiftlang-700.0.59/src/swift/stdlib/public/core/ErrorType.swift, line 50

Running multiple tests the database seems to be corrupted, maybe caused by sqlite temporary files. 

I've improved NSPersistentStore deletion in tearDown. 

Thanks